### PR TITLE
added support for 'hard' vs. 'soft' wrapping (also code-coverage).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.nyc_output

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ node_js:
   - 'iojs'
   - '0.12'
   - '0.10'
+after_success: npm run coverage

--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ function invoke(str, cols, opts) {
 			continue;
 		}
 
-		if (rowLength + lengths[i] > cols) {
+		if (rowLength + lengths[i] > cols && rowLength) {
 			rows.push('');
 		}
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "xo && node test.js"
+    "test": "xo && nyc node test.js",
+    "coverage": "xo && nyc --reporter=text-lcov node test.js | coveralls"
   },
   "files": [
     "index.js"
@@ -51,12 +52,13 @@
     "text"
   ],
   "dependencies": {
-    "splice-string": "^1.0.0"
+    "strip-ansi": "^3.0.0"
   },
   "devDependencies": {
     "ava": "0.0.4",
     "chalk": "^1.1.0",
-    "strip-ansi": "^3.0.0",
+    "coveralls": "^2.11.4",
+    "nyc": "^3.2.2",
     "xo": "*"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,18 @@ console.log(wrapAnsi(input, 20));
 
 ## API
 
-### wrapAnsi(input, columns)
+### wrapAnsi(input, columns, opts)
+
+wrap words to the specified column width. By default the wrap is
+`soft`, so long words may extend past the column length.
+
+### wrapAnsi.hard(input, columns)
+
+long words will be broken up so that they do not extend past the column width.
+
+### wrapAnsi.soft(input, columns)
+
+long words will not be broken up.
 
 #### input
 
@@ -46,7 +57,7 @@ Number of columns to wrap the text to.
 
 - [slice-ansi](https://github.com/chalk/slice-ansi) - Slice a string with ANSI escape codes
 - [chalk](https://github.com/chalk/chalk) - Terminal string styling done right
-
+- [jsesc](https://github.com/mathiasbynens/jsesc) - Generate ascii only output from unicode strings. This is useful for creating testing fixtures.
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,8 @@
 # wrap-ansi [![Build Status](https://travis-ci.org/chalk/wrap-ansi.svg?branch=master)](https://travis-ci.org/chalk/wrap-ansi)
 
+[![Coverage Status](https://coveralls.io/repos/chalk/wrap-ansi/badge.svg?branch=master)](https://coveralls.io/r/chalk/wrap-ansi?branch=master)
+
+
 > Wordwrap a string with [ANSI escape codes](http://en.wikipedia.org/wiki/ANSI_escape_code#Colors_and_Styles)
 
 

--- a/test.js
+++ b/test.js
@@ -7,17 +7,24 @@ var fn = require('./');
 var fixture = 'The quick brown ' + chalk.red('fox jumped over ') + 'the lazy ' + chalk.green('dog and then ran away with the unicorn.');
 
 test(function (t) {
+	var res5 = fn.hard(fixture, 5);
 	var res20 = fn(fixture, 20);
 	var res30 = fn(fixture, 30);
 
-	t.assert(res20 === 'The quick brown\n\u001b[31mfox jumped over \u001b[39mthe\nlazy \u001b[32mdog and then\u001b[39m\n\u001b[32mran away with the\u001b[39m\n\u001b[32municorn.\u001b[39m');
+	t.assert(res20 === 'The quick brown \x1B[31mfox\x1B[39m\n\x1B[31mjumped over \x1B[39mthe lazy\n\x1B[32mdog and then ran\x1B[39m\n\x1B[32maway with the\x1B[39m\n\x1B[32municorn.\x1B[39m');
 	t.assert(stripAnsi(res20).split('\n').every(function (x) {
 		return x.length <= 20;
 	}));
 
-	t.assert(res30 === 'The quick brown \u001b[31mfox jumped\u001b[39m\n\u001b[31mover \u001b[39mthe lazy \u001b[32mdog and then\u001b[39m\n\u001b[32mran away with the unicorn.\u001b[39m');
+	t.assert(res30 === 'The quick brown \x1B[31mfox jumped\x1B[39m\n\x1B[31mover \x1B[39mthe lazy \x1B[32mdog and then ran\x1B[39m\n\x1B[32maway with the unicorn.\x1B[39m');
 	t.assert(stripAnsi(res30).split('\n').every(function (x) {
 		return x.length <= 30;
+	}));
+
+	// words greate than 5 characters, e.g., unicorn., will be split onto multiple lines.
+	t.assert(res5 === 'The\nquick\nbrown\n\x1B[31mfox\x1B[39m\n\x1B[31mjumpe\x1B[39m\n\x1B[31md\x1B[39m\n\x1B[31mover\x1B[39m\n\x1B[31m\x1B[39mthe\nlazy\n\x1B[32mdog\x1B[39m\n\x1B[32mand\x1B[39m\n\x1B[32mthen\x1B[39m\n\x1B[32mran\x1B[39m\n\x1B[32maway\x1B[39m\n\x1B[32mwith\x1B[39m\n\x1B[32mthe\x1B[39m\n\x1B[32munico\x1B[39m\n\x1B[32mrn.\x1B[39m');
+	t.assert(stripAnsi(res5).split('\n').every(function (x) {
+		return x.length <= 5;
 	}));
 
 	t.end();


### PR DESCRIPTION
In this pull request I've added support for the concept of `hard` vs. `soft` wrapping:

`soft` wrapping allows words that take up more than `cols` to be printed on a single line.

`hard` wrapping does not allow a row to ever contain more than `cols` characters.

This functionality is modeled after @substack's [node-wordwrap](https://github.com/substack/node-wordwrap).

In this pull I've also added code coverage support, which helps me ensure that I'm not being lazy while writing tests.

## How I Tested Hard vs. Soft Wrapping

1. I wrote a testing script that allowed me to compare substack's wordwrap library, to the ansi wordwrap module. wordwrap is used by `cliui` and `yargs`, and my goal was to make `ansi-wordwrap` a drop in replacement. Here's the script I wrote:

```js
var assert = require('assert');
var stripAnsi = require('strip-ansi');
var chalk = require('chalk');

var fixture = 'The thisisareallylongword quick brown ' + chalk.red('fox jumped over ') + 'the lazy ' + chalk.green('dog and then ran away with the unicorn.');
var wrap = require('./');
var wrap2 = require('wordwrap');

for (var cols = 1; cols < 30; cols++) {
  console.log('cols = ', cols);
  console.log(wrap(fixture, cols, {hard: true}), '\n---');
  console.log(wrap2.hard(cols)(stripAnsi(fixture)), '\n---');
  assert.equal(stripAnsi(wrap(fixture, cols, {hard: true})), wrap2.hard(cols)(stripAnsi(fixture)));
}
```

I used this script to compare both `soft` and `hard` wrapping between the two modules, and managed to get the output pretty close to parity (I actually think that I found a few bugs in wordwrap, that are not present in ansi-wrap related to wrapping close to column boundaries) \o/

![screen shot 2015-10-04 at 2 24 08 pm](https://cloud.githubusercontent.com/assets/194609/10270382/acf548ce-6aa4-11e5-8b23-44a3a3792732.png)

2. my second test was to `npm link`, `wrap-ansi` and use it as a drop in replacement for `wordwrap`. Both the `yargs` and `cliui` codebases run with the replacement.

## Wrap Ansi Now Has Code Coverage

I added code-coverage support, to help ensure that I wasn't making a mess while undertaking this refactor:

![screen shot 2015-10-04 at 2 23 24 pm](https://cloud.githubusercontent.com/assets/194609/10270434/fe762b90-6aa5-11e5-9ed0-565000480fa6.png)

To enable the coverage badge:

1. visit https://coveralls.io/ and enable code-coverage for this repo.
2. set the COVERALLS_TOKEN repo in travis.

Let me know anything you'd like changed in this pull, would love to use this as a drop in replacement in `yargs`.

reviewers: @dthre, @sindresorhus, @phated, @nexdrew