### PR TITLE
adds test coverage to wrap-ansi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.nyc_output

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ node_js:
   - 'iojs'
   - '0.12'
   - '0.10'
+after_success: npm run coverage

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "test": "xo && nyc node test.js",
-    "coverage": "xo && nyc --reporter=text-lcov node test.js | coveralls"
+    "coverage": "nyc --reporter=text-lcov node test.js | coveralls"
   },
   "files": [
     "index.js"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "xo && node test.js"
+    "test": "xo && nyc node test.js",
+    "coverage": "xo && nyc --reporter=text-lcov node test.js | coveralls"
   },
   "files": [
     "index.js"
@@ -56,6 +57,8 @@
   "devDependencies": {
     "ava": "0.0.4",
     "chalk": "^1.1.0",
+    "coveralls": "^2.11.4",
+    "nyc": "^3.2.2",
     "strip-ansi": "^3.0.0",
     "xo": "*"
   }

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,5 @@
-# wrap-ansi [![Build Status](https://travis-ci.org/chalk/wrap-ansi.svg?branch=master)](https://travis-ci.org/chalk/wrap-ansi)
+# wrap-ansi [![Build Status](https://travis-ci.org/chalk/wrap-ansi.svg?branch=master)](https://travis-ci.org/chalk/wrap-ansi) [![Coverage Status](https://coveralls.io/repos/chalk/wrap-ansi/badge.svg?branch=master)](https://coveralls.io/r/chalk/wrap-ansi?branch=master)
+
 
 > Wordwrap a string with [ANSI escape codes](http://en.wikipedia.org/wiki/ANSI_escape_code#Colors_and_Styles)
 


### PR DESCRIPTION
I've added code-coverage to wrap-ansi, to help keep me honest as I undertake the refactoring work for `wrap-hard` support.

![screen shot 2015-10-04 at 2 23 24 pm](https://cloud.githubusercontent.com/assets/194609/10270434/fe762b90-6aa5-11e5-9ed0-565000480fa6.png)

To enable coverage badge:

1. visit https://coveralls.io/ and enable code-coverage for this repo.
2. set the COVERALLS_TOKEN repo in travis.

Let me know anything you'd like changed in this pull, would love to use this as a drop in replacement in `yargs`.

reviewers: @dthre, @sindresorhus, @phated, @nexdrew