### PR TITLE
adds hard wrapping functionality

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ function wrapWord(rows, word, cols) {
 // than cols characters.
 //
 // 'soft' allows long words to expand past the column length.
-function invoke(str, cols, opts) {
+module.exports = function (str, cols, opts) {
 	var options = opts || {};
 
 	var pre = '';
@@ -165,16 +165,4 @@ function invoke(str, cols, opts) {
 	}
 
 	return ret;
-}
-
-// strings never extend past 'cols'.
-invoke.hard = function (str, cols) {
-	return invoke(str, cols, {hard: true});
 };
-
-// long words sometimes extend past 'cols'.
-invoke.soft = function (str, cols) {
-	return invoke(str, cols, {hard: false});
-};
-
-module.exports = invoke;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 'use strict';
-var stripAnsi = require('strip-ansi');
 var stringWidth = require('string-width');
 
 var ESCAPES = [
@@ -107,7 +106,7 @@ function invoke(str, cols, opts) {
 	var rows = [''];
 
 	for (var i = 0, word; (word = words[i]) !== undefined; i++) {
-		var rowLength = stripAnsi(rows[rows.length - 1]).length;
+		var rowLength = stringWidth(rows[rows.length - 1]);
 
 		if (rowLength) {
 			rows[rows.length - 1] += ' ';

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 var stripAnsi = require('strip-ansi');
+var stringWidth = require('string-width');
 
 var ESCAPES = [
 	'\u001b',
@@ -43,8 +44,8 @@ function wrapAnsi(code) {
 // calculate the length of words split on ' ', ignoring
 // the extra characters added by ansi escape codes.
 function wordLengths(str) {
-	return stripAnsi(str).split(' ').map(function (s) {
-		return s.length;
+	return str.split(' ').map(function (s) {
+		return stringWidth(s);
 	});
 }
 

--- a/package.json
+++ b/package.json
@@ -52,14 +52,14 @@
     "text"
   ],
   "dependencies": {
-    "string-width": "^1.0.1",
-    "strip-ansi": "^3.0.0"
+    "string-width": "^1.0.1"
   },
   "devDependencies": {
     "ava": "0.0.4",
     "chalk": "^1.1.0",
     "coveralls": "^2.11.4",
     "nyc": "^3.2.2",
+    "strip-ansi": "^3.0.0",
     "xo": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,14 +52,13 @@
     "text"
   ],
   "dependencies": {
-    "splice-string": "^1.0.0"
+    "strip-ansi": "^3.0.0"
   },
   "devDependencies": {
     "ava": "0.0.4",
     "chalk": "^1.1.0",
     "coveralls": "^2.11.4",
     "nyc": "^3.2.2",
-    "strip-ansi": "^3.0.0",
     "xo": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "text"
   ],
   "dependencies": {
+    "string-width": "^1.0.1",
     "strip-ansi": "^3.0.0"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -35,15 +35,6 @@ the following options can be provided:
 
 * `hard`: `boolean`, should hard wrapping be enabled?
 
-### wrapAnsi.hard(input, columns)
-
-long words will be broken up so that they do not extend past the column width.
-Equivalent to `{hard: true}`.
-
-### wrapAnsi.soft(input, columns)
-
-long words will not be broken up. Equivalent to `{hard: false}`.
-
 #### input
 
 Type: `string`

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,6 @@
 
 > Wordwrap a string with [ANSI escape codes](http://en.wikipedia.org/wiki/ANSI_escape_code#Colors_and_Styles)
 
-
 ## Install
 
 ```
@@ -27,7 +26,22 @@ console.log(wrapAnsi(input, 20));
 
 ## API
 
-### wrapAnsi(input, columns)
+### wrapAnsi(input, columns, opts)
+
+wrap words to the specified column width. By default the wrap is
+`soft`, so long words may extend past the column length.
+
+the following options can be provided:
+
+* `hard`: `boolean`, should hard wrapping be enabled?
+
+### wrapAnsi.hard(input, columns)
+
+long words will be broken up so that they do not extend past the column width.
+
+### wrapAnsi.soft(input, columns)
+
+long words will not be broken up.
 
 #### input
 
@@ -46,7 +60,7 @@ Number of columns to wrap the text to.
 
 - [slice-ansi](https://github.com/chalk/slice-ansi) - Slice a string with ANSI escape codes
 - [chalk](https://github.com/chalk/chalk) - Terminal string styling done right
-
+- [jsesc](https://github.com/mathiasbynens/jsesc) - Generate ASCII-only output from Unicode strings. Useful for creating testing fixtures.
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -38,10 +38,11 @@ the following options can be provided:
 ### wrapAnsi.hard(input, columns)
 
 long words will be broken up so that they do not extend past the column width.
+Equivalent to `{hard: true}`.
 
 ### wrapAnsi.soft(input, columns)
 
-long words will not be broken up.
+long words will not be broken up. Equivalent to `{hard: false}`.
 
 #### input
 

--- a/readme.md
+++ b/readme.md
@@ -28,8 +28,7 @@ console.log(wrapAnsi(input, 20));
 
 ### wrapAnsi(input, columns, opts)
 
-wrap words to the specified column width. By default the wrap is
-`soft`, so long words may extend past the column length.
+wrap words to the specified column width. By default the wrap is `soft`, so long words may extend past the column length.
 
 the following options can be provided:
 

--- a/test.js
+++ b/test.js
@@ -7,17 +7,24 @@ var fn = require('./');
 var fixture = 'The quick brown ' + chalk.red('fox jumped over ') + 'the lazy ' + chalk.green('dog and then ran away with the unicorn.');
 
 test(function (t) {
+	var res5 = fn.hard(fixture, 5);
 	var res20 = fn(fixture, 20);
 	var res30 = fn(fixture, 30);
 
-	t.assert(res20 === 'The quick brown\n\u001b[31mfox jumped over \u001b[39mthe\nlazy \u001b[32mdog and then\u001b[39m\n\u001b[32mran away with the\u001b[39m\n\u001b[32municorn.\u001b[39m');
+	t.assert(res20 === 'The quick brown \x1B[31mfox\x1B[39m\n\x1B[31mjumped over \x1B[39mthe lazy\n\x1B[32mdog and then ran\x1B[39m\n\x1B[32maway with the\x1B[39m\n\x1B[32municorn.\x1B[39m');
 	t.assert(stripAnsi(res20).split('\n').every(function (x) {
 		return x.length <= 20;
 	}));
 
-	t.assert(res30 === 'The quick brown \u001b[31mfox jumped\u001b[39m\n\u001b[31mover \u001b[39mthe lazy \u001b[32mdog and then\u001b[39m\n\u001b[32mran away with the unicorn.\u001b[39m');
+	t.assert(res30 === 'The quick brown \x1B[31mfox jumped\x1B[39m\n\x1B[31mover \x1B[39mthe lazy \x1B[32mdog and then ran\x1B[39m\n\x1B[32maway with the unicorn.\x1B[39m');
 	t.assert(stripAnsi(res30).split('\n').every(function (x) {
 		return x.length <= 30;
+	}));
+
+	// words greate than 5 characters, e.g., unicorn., will be split onto multiple lines.
+	t.assert(res5 === 'The\nquick\nbrown\n\x1B[31mfox\x1B[39m\n\x1B[31mjumpe\x1B[39m\n\x1B[31md\x1B[39m\n\x1B[31mover\x1B[39m\n\x1B[31m\x1B[39mthe\nlazy\n\x1B[32mdog\x1B[39m\n\x1B[32mand\x1B[39m\n\x1B[32mthen\x1B[39m\n\x1B[32mran\x1B[39m\n\x1B[32maway\x1B[39m\n\x1B[32mwith\x1B[39m\n\x1B[32mthe\x1B[39m\n\x1B[32munico\x1B[39m\n\x1B[32mrn.\x1B[39m');
+	t.assert(stripAnsi(res5).split('\n').every(function (x) {
+		return x.length <= 5;
 	}));
 
 	t.end();

--- a/test.js
+++ b/test.js
@@ -7,7 +7,7 @@ var fn = require('./');
 var fixture = 'The quick brown ' + chalk.red('fox jumped over ') + 'the lazy ' + chalk.green('dog and then ran away with the unicorn.');
 
 test(function (t) {
-	var res5 = fn.hard(fixture, 5);
+	var res5 = fn(fixture, 5, {hard: true});
 	var res20 = fn(fixture, 20);
 	var res30 = fn(fixture, 30);
 

--- a/test.js
+++ b/test.js
@@ -11,18 +11,18 @@ test(function (t) {
 	var res20 = fn(fixture, 20);
 	var res30 = fn(fixture, 30);
 
-	t.assert(res20 === 'The quick brown \x1B[31mfox\x1B[39m\n\x1B[31mjumped over \x1B[39mthe lazy\n\x1B[32mdog and then ran\x1B[39m\n\x1B[32maway with the\x1B[39m\n\x1B[32municorn.\x1B[39m');
+	t.assert(res20 === 'The quick brown \u001b[31mfox\u001b[39m\n\u001b[31mjumped over \u001b[39mthe lazy\n\u001b[32mdog and then ran\u001b[39m\n\u001b[32maway with the\u001b[39m\n\u001b[32municorn.\u001b[39m');
 	t.assert(stripAnsi(res20).split('\n').every(function (x) {
 		return x.length <= 20;
 	}));
 
-	t.assert(res30 === 'The quick brown \x1B[31mfox jumped\x1B[39m\n\x1B[31mover \x1B[39mthe lazy \x1B[32mdog and then ran\x1B[39m\n\x1B[32maway with the unicorn.\x1B[39m');
+	t.assert(res30 === 'The quick brown \u001b[31mfox jumped\u001b[39m\n\u001b[31mover \u001b[39mthe lazy \u001b[32mdog and then ran\u001b[39m\n\u001b[32maway with the unicorn.\u001b[39m');
 	t.assert(stripAnsi(res30).split('\n').every(function (x) {
 		return x.length <= 30;
 	}));
 
 	// words greater than 5 characters, e.g., unicorn., will be split onto multiple lines.
-	t.assert(res5 === 'The\nquick\nbrown\n\x1B[31mfox\x1B[39m\n\x1B[31mjumpe\x1B[39m\n\x1B[31md\x1B[39m\n\x1B[31mover\x1B[39m\n\x1B[31m\x1B[39mthe\nlazy\n\x1B[32mdog\x1B[39m\n\x1B[32mand\x1B[39m\n\x1B[32mthen\x1B[39m\n\x1B[32mran\x1B[39m\n\x1B[32maway\x1B[39m\n\x1B[32mwith\x1B[39m\n\x1B[32mthe\x1B[39m\n\x1B[32munico\x1B[39m\n\x1B[32mrn.\x1B[39m');
+	t.assert(res5 === 'The\nquick\nbrown\n\u001b[31mfox\u001b[39m\n\u001b[31mjumpe\u001b[39m\n\u001b[31md\u001b[39m\n\u001b[31mover\u001b[39m\n\u001b[31m\u001b[39mthe\nlazy\n\u001b[32mdog\u001b[39m\n\u001b[32mand\u001b[39m\n\u001b[32mthen\u001b[39m\n\u001b[32mran\u001b[39m\n\u001b[32maway\u001b[39m\n\u001b[32mwith\u001b[39m\n\u001b[32mthe\u001b[39m\n\u001b[32munico\u001b[39m\n\u001b[32mrn.\u001b[39m');
 	t.assert(stripAnsi(res5).split('\n').every(function (x) {
 		return x.length <= 5;
 	}));

--- a/test.js
+++ b/test.js
@@ -21,7 +21,7 @@ test(function (t) {
 		return x.length <= 30;
 	}));
 
-	// words greate than 5 characters, e.g., unicorn., will be split onto multiple lines.
+	// words greater than 5 characters, e.g., unicorn., will be split onto multiple lines.
 	t.assert(res5 === 'The\nquick\nbrown\n\x1B[31mfox\x1B[39m\n\x1B[31mjumpe\x1B[39m\n\x1B[31md\x1B[39m\n\x1B[31mover\x1B[39m\n\x1B[31m\x1B[39mthe\nlazy\n\x1B[32mdog\x1B[39m\n\x1B[32mand\x1B[39m\n\x1B[32mthen\x1B[39m\n\x1B[32mran\x1B[39m\n\x1B[32maway\x1B[39m\n\x1B[32mwith\x1B[39m\n\x1B[32mthe\x1B[39m\n\x1B[32munico\x1B[39m\n\x1B[32mrn.\x1B[39m');
 	t.assert(stripAnsi(res5).split('\n').every(function (x) {
 		return x.length <= 5;


### PR DESCRIPTION
In this pull request I've added support for the concept of `hard` vs. `soft` wrapping:

`soft` wrapping allows words that take up more than `cols` to be printed on a single line.

`hard` wrapping does not allow a row to ever contain more than `cols` characters.

This functionality is modeled after @substack's [node-wordwrap](https://github.com/substack/node-wordwrap).

In this pull I've also added code coverage support, which helps me ensure that I'm not being lazy while writing tests.

## How I Tested

1. I wrote a testing script that allowed me to compare substack's wordwrap library, to the ansi wordwrap module. wordwrap is used by `cliui` and `yargs`, and my goal was to make `ansi-wordwrap` a drop in replacement. Here's the script I wrote:

```js
var assert = require('assert');
var stripAnsi = require('strip-ansi');
var chalk = require('chalk');

var fixture = 'The thisisareallylongword quick brown ' + chalk.red('fox jumped over ') + 'the lazy ' + chalk.green('dog and then ran away with the unicorn.');
var wrap = require('./');
var wrap2 = require('wordwrap');

for (var cols = 1; cols < 30; cols++) {
  console.log('cols = ', cols);
  console.log(wrap(fixture, cols, {hard: true}), '\n---');
  console.log(wrap2.hard(cols)(stripAnsi(fixture)), '\n---');
  assert.equal(stripAnsi(wrap(fixture, cols, {hard: true})), wrap2.hard(cols)(stripAnsi(fixture)));
}
```

I used this script to compare both `soft` and `hard` wrapping between the two modules, and managed to get the output pretty close to parity (I actually think that I found a few bugs in wordwrap, that are not present in ansi-wrap related to wrapping close to column boundaries) \o/

![screen shot 2015-10-04 at 2 24 08 pm](https://cloud.githubusercontent.com/assets/194609/10270382/acf548ce-6aa4-11e5-8b23-44a3a3792732.png)

2. my second test was to `npm link`, `wrap-ansi` and use it as a drop in replacement for `wordwrap`. Both the `yargs` and `cliui` codebases run with the replacement.

reviewers: @dthre, @sindresorhus, @phated, @nexdrew

_note: I started out by trying to tack this functionality onto the existing algorithm, but it turned out to be a hard enough problem that refactoring the algorithm seemed like the better approach._
