### PR TITLE
chore: remove 0.10 and 0.12 from the testing matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - '5'
   - '4'
+  - 'node'
 after_success: npm run coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,4 @@ language: node_js
 node_js:
   - '5'
   - '4'
-  - '0.12'
-  - '0.10'
 after_success: npm run coveralls


### PR DESCRIPTION
Remove 0.10 and 0.12 from the testing matrix, as AVA no longer supports these versions.