### PR TITLE
Add option to not remove whitespace - fixes #9

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ const exec = (str, cols, opts) => {
 
 		let rowLength = stringWidth(rows[rows.length - 1]);
 
-		if (rowLength) {
+		if (rowLength || word === '') {
 			rows[rows.length - 1] += ' ';
 			rowLength++;
 		}
@@ -145,7 +145,7 @@ const exec = (str, cols, opts) => {
 		rows[rows.length - 1] += word;
 	}
 
-	pre = rows.map(x => x.trim()).join('\n');
+	pre = rows.map(r => options.trim === false ? r : r.trim()).join('\n');
 
 	for (const item of Array.from(pre).entries()) {
 		const i = item[0];

--- a/index.js
+++ b/index.js
@@ -111,7 +111,8 @@ const exec = (str, cols, opts) => {
 		const i = item[0];
 		const word = item[1];
 
-		let rowLength = stringWidth(options.trim === false ? rows[rows.length - 1] : rows[rows.length - 1].trim());
+		rows[rows.length - 1] = options.trim === false ? rows[rows.length - 1] : rows[rows.length - 1].trim();
+		let rowLength = stringWidth(rows[rows.length - 1]);
 
 		if (rowLength || word === '') {
 			if (rowLength === cols && options.wordWrap === false) {

--- a/index.js
+++ b/index.js
@@ -111,9 +111,15 @@ const exec = (str, cols, opts) => {
 		const i = item[0];
 		const word = item[1];
 
-		let rowLength = stringWidth(rows[rows.length - 1]);
+		let rowLength = stringWidth(options.trim === false ? rows[rows.length - 1] : rows[rows.length - 1].trim());
 
 		if (rowLength || word === '') {
+			if (rowLength === cols && options.wordWrap === false) {
+				// If we start with a new word but the current row length equals the length of the columns, add a new row
+				rows.push('');
+				rowLength = 0;
+			}
+
 			rows[rows.length - 1] += ' ';
 			rowLength++;
 		}

--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,13 @@ Default: `true`
 
 By default, an attempt is made to split words at spaces, ensuring that they don't extend past the configured columns. If wordWrap is `false`, each column will instead be completely filled splitting words as necessary.
 
+##### trim
+
+Type: `boolean`<br>
+Default: `true`
+
+Whitespace on all lines is removed by default. Set this option to `false` if you don't want to trim.
+
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -91,11 +91,15 @@ test('no word-wrapping and no trimming', t => {
 	t.is(res, '12345678\n901234567890 \n12345');
 
 	const res2 = m(fixture, 5, {wordWrap: false, trim: false});
+<<<<<<< 59f01f50129d64264b9ac8e94d01539ff52c9271
 <<<<<<< eb6aa7fe5e8d37bd577b1bc3a7c8d79bf4402975
 	t.is(res2, 'The q\nuick \nbrown \n[31mfox j[39m\n[31mumped [39m\n[31mover [39m\n[31m[39mthe l\nazy [32md[39m\n[32mog an[39m\n[32md the[39m\n[32mn ran [39m\n[32maway [39m\n[32mwith [39m\n[32mthe u[39m\n[32mnicor[39m\n[32mn.[39m');
 =======
 	t.is(res2, 'The q\nuick \nbrown \n\u001B[31mfox j\u001B[39m\n\u001B[31mumped \u001B[39m\n\u001B[31mover \u001B[39m\n\u001B[31m\u001B[39mthe l\nazy \u001B[32md\u001B[39m\n\u001B[32mog an\u001B[39m\n\u001B[32md the\u001B[39m\n\u001B[32mn ran \u001B[39m\n\u001B[32maway \u001B[39m\n\u001B[32mwith \u001B[39m\n\u001B[32mthe u\u001B[39m\n\u001B[32mnicor\u001B[39m\n\u001B[32mn.\u001B[39m');
 >>>>>>> Update test.js
+=======
+	t.is(res2, 'The q\nuick \nbrown\n \u001B[31mfox \u001B[39m\n[31mjumpe[39m\n[31md ove[39m\n[31mr \u001B[39mthe\n lazy\n \u001B[32mdog \u001B[39m\n[32mand t[39m\n[32mhen r[39m\n[32man aw[39m\n[32may wi[39m\n[32mth th[39m\n[32me uni[39m\n[32mcorn.\u001B[39m');
+>>>>>>> fix trimming
 });
 
 test('supports fullwidth characters', t => {

--- a/test.js
+++ b/test.js
@@ -86,6 +86,14 @@ test('no word-wrapping', t => {
 	t.is(res3, 'The q\nuick\nbrown\n\u001B[31mfox j\u001B[39m\n\u001B[31mumped\u001B[39m\n\u001B[31mover\u001B[39m\n\u001B[31m\u001B[39mthe l\nazy \u001B[32md\u001B[39m\n\u001B[32mog an\u001B[39m\n\u001B[32md the\u001B[39m\n\u001B[32mn ran\u001B[39m\n\u001B[32maway\u001B[39m\n\u001B[32mwith\u001B[39m\n\u001B[32mthe u\u001B[39m\n\u001B[32mnicor\u001B[39m\n\u001B[32mn.\u001B[39m');
 });
 
+test('no word-wrapping and no trimming', t => {
+	const res = m(fixture3, 10, {wordWrap: false, trim: false});
+	t.is(res, '12345678\n901234567890 \n12345');
+
+	const res2 = m(fixture, 5, {wordWrap: false, trim: false});
+	t.is(res2, 'The q\nuick \nbrown \n[31mfox j[39m\n[31mumped [39m\n[31mover [39m\n[31m[39mthe l\nazy [32md[39m\n[32mog an[39m\n[32md the[39m\n[32mn ran [39m\n[32maway [39m\n[32mwith [39m\n[32mthe u[39m\n[32mnicor[39m\n[32mn.[39m');
+});
+
 test('supports fullwidth characters', t => {
 	t.is(m('안녕하세', 4, {hard: true}), '안녕\n하세');
 });

--- a/test.js
+++ b/test.js
@@ -91,15 +91,7 @@ test('no word-wrapping and no trimming', t => {
 	t.is(res, '12345678\n901234567890 \n12345');
 
 	const res2 = m(fixture, 5, {wordWrap: false, trim: false});
-<<<<<<< 59f01f50129d64264b9ac8e94d01539ff52c9271
-<<<<<<< eb6aa7fe5e8d37bd577b1bc3a7c8d79bf4402975
-	t.is(res2, 'The q\nuick \nbrown \n[31mfox j[39m\n[31mumped [39m\n[31mover [39m\n[31m[39mthe l\nazy [32md[39m\n[32mog an[39m\n[32md the[39m\n[32mn ran [39m\n[32maway [39m\n[32mwith [39m\n[32mthe u[39m\n[32mnicor[39m\n[32mn.[39m');
-=======
-	t.is(res2, 'The q\nuick \nbrown \n\u001B[31mfox j\u001B[39m\n\u001B[31mumped \u001B[39m\n\u001B[31mover \u001B[39m\n\u001B[31m\u001B[39mthe l\nazy \u001B[32md\u001B[39m\n\u001B[32mog an\u001B[39m\n\u001B[32md the\u001B[39m\n\u001B[32mn ran \u001B[39m\n\u001B[32maway \u001B[39m\n\u001B[32mwith \u001B[39m\n\u001B[32mthe u\u001B[39m\n\u001B[32mnicor\u001B[39m\n\u001B[32mn.\u001B[39m');
->>>>>>> Update test.js
-=======
 	t.is(res2, 'The q\nuick \nbrown\n \u001B[31mfox \u001B[39m\n[31mjumpe[39m\n[31md ove[39m\n[31mr \u001B[39mthe\n lazy\n \u001B[32mdog \u001B[39m\n[32mand t[39m\n[32mhen r[39m\n[32man aw[39m\n[32may wi[39m\n[32mth th[39m\n[32me uni[39m\n[32mcorn.\u001B[39m');
->>>>>>> fix trimming
 });
 
 test('supports fullwidth characters', t => {

--- a/test.js
+++ b/test.js
@@ -87,7 +87,7 @@ test('no word-wrapping', t => {
 });
 
 test('no word-wrapping and no trimming', t => {
-	const res = m(fixture3, 10, {wordWrap: false, trim: false});
+	const res = m(fixture3, 13, {wordWrap: false, trim: false});
 	t.is(res, '12345678\n901234567890 \n12345');
 
 	const res2 = m(fixture, 5, {wordWrap: false, trim: false});

--- a/test.js
+++ b/test.js
@@ -91,7 +91,11 @@ test('no word-wrapping and no trimming', t => {
 	t.is(res, '12345678\n901234567890 \n12345');
 
 	const res2 = m(fixture, 5, {wordWrap: false, trim: false});
+<<<<<<< eb6aa7fe5e8d37bd577b1bc3a7c8d79bf4402975
 	t.is(res2, 'The q\nuick \nbrown \n[31mfox j[39m\n[31mumped [39m\n[31mover [39m\n[31m[39mthe l\nazy [32md[39m\n[32mog an[39m\n[32md the[39m\n[32mn ran [39m\n[32maway [39m\n[32mwith [39m\n[32mthe u[39m\n[32mnicor[39m\n[32mn.[39m');
+=======
+	t.is(res2, 'The q\nuick \nbrown \n\u001B[31mfox j\u001B[39m\n\u001B[31mumped \u001B[39m\n\u001B[31mover \u001B[39m\n\u001B[31m\u001B[39mthe l\nazy \u001B[32md\u001B[39m\n\u001B[32mog an\u001B[39m\n\u001B[32md the\u001B[39m\n\u001B[32mn ran \u001B[39m\n\u001B[32maway \u001B[39m\n\u001B[32mwith \u001B[39m\n\u001B[32mthe u\u001B[39m\n\u001B[32mnicor\u001B[39m\n\u001B[32mn.\u001B[39m');
+>>>>>>> Update test.js
 });
 
 test('supports fullwidth characters', t => {


### PR DESCRIPTION
This PR tries to solve issue #9 where `wrap-ansi` removes leading and trailing whitespace by default.

Although the tests succeed, and `log-update` works again as expected, I don't think it's really the expected output that we get in the tests.

When I highlight the output, this is what I see

<img width="86" alt="screen shot 2017-06-13 at 22 17 58" src="https://user-images.githubusercontent.com/1913805/27102627-34bed892-5086-11e7-81d0-80ca900feca1.png">

I don't think I should have those extra whitespace character (1 in green, 1 in red). I believe they should be added to the next line instead. So I will have a look at how I can solve that.

But please, feedback is more than appreciated! For instance, should we have extend the `trim` option to also accept `leading`, `trailing` so that users can choose to only remove trailing or only remove leading whitespaces? `log-update` for instance should have enough by only trimming the trailing whitespace.

// @SBoudrias @sindresorhus @Qix- @bcoe