### PR TITLE
Handle spaces inside background color escapes

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,30 +86,30 @@ const exec = (string, columns, options = {}) => {
 	let normalizedStringParts = [];
 
 	// Look for all background color ansi escapes
-	const bgColorEscape = /(\u001b\[(4[0-7]|10[0-7])m.*?\u001b\[49m)/g
-	let match
-	let lastMatch
+	const bgColorEscape = /(\u001b\[(4[0-7]|10[0-7])m.*?\u001b\[49m)/g; // eslint-disable-line no-control-regex
+	let match;
+	let lastMatch;
 
 	while ((match = bgColorEscape.exec(string)) !== null) {
 		if (normalizedStringParts.length === 0) {
 			// Add string part before first background color escape
-			normalizedStringParts.push(...string.slice(0, match.index).split(' ').slice(0, -1))
+			normalizedStringParts.push(...string.slice(0, match.index).split(' ').slice(0, -1));
 		}
 
-		normalizedStringParts.push(match[0])
-		lastMatch = match
+		normalizedStringParts.push(match[0]);
+		lastMatch = match;
 	}
 
 	if (lastMatch) {
 		// Add remaining string after last background color escape
-		const remainingString = string.slice(lastMatch.index + lastMatch[0].length)
+		const remainingString = string.slice(lastMatch.index + lastMatch[0].length);
 
 		if (remainingString.length > 0) {
-			normalizedStringParts.push(...remainingString.split(' ').slice(0, -1))
+			normalizedStringParts.push(...remainingString.split(' ').slice(0, -1));
 		}
 	} else {
 		// If there is no match, it means there are no background color escapes
-		normalizedStringParts = stringParts
+		normalizedStringParts = stringParts;
 	}
 
 	for (const [index, word] of normalizedStringParts.entries()) {

--- a/test.js
+++ b/test.js
@@ -66,7 +66,7 @@ test('handles nested color escapes', t => {
 test('handle ending space within a color escape', t => {
 	const res = m(chalk.bgGreen(' hello ' + chalk.red('world') + ' '), 10, {hard: true, trim: false});
 	t.is(res, chalk.bgGreen(' hello ' + chalk.red('world') + ' '));
-})
+});
 
 // When "hard" is true
 

--- a/test.js
+++ b/test.js
@@ -63,6 +63,11 @@ test('handles nested color escapes', t => {
 	t.is(res, chalk.bgGreen(' hello ' + chalk.red('world')));
 });
 
+test('handle ending space within a color escape', t => {
+	const res = m(chalk.bgGreen(' hello ' + chalk.red('world') + ' '), 10, {hard: true, trim: false});
+	t.is(res, chalk.bgGreen(' hello ' + chalk.red('world') + ' '));
+})
+
 // When "hard" is true
 
 test('breaks strings longer than "cols" characters', t => {

--- a/test.js
+++ b/test.js
@@ -48,6 +48,21 @@ test('does not prepend newline if first string is greater than "cols"', t => {
 	t.is(res.split('\n').length, 1);
 });
 
+test('does not trim beginning of string if it starts with a space and wrapped into background color escape', t => {
+	const res = m(chalk.bgGreen(' hello '), 10, {hard: true, trim: false});
+	t.is(res, chalk.bgGreen(' hello '));
+});
+
+test('trim beginning of string if it starts with a space and not wrapped into background color escape', t => {
+	const res = m(chalk.green(' hello '), 10, {hard: true, trim: false});
+	t.is(res, chalk.green('hello '));
+});
+
+test('handles nested color escapes', t => {
+	const res = m(chalk.bgGreen(' hello ' + chalk.red('world')), 10, {hard: true, trim: false});
+	t.is(res, chalk.bgGreen(' hello ' + chalk.red('world')));
+});
+
 // When "hard" is true
 
 test('breaks strings longer than "cols" characters', t => {


### PR DESCRIPTION
Fixes https://github.com/chalk/wrap-ansi/issues/27.

The original issue is about `wrap-ansi` stripping the beginning space, if string is wrapped into an ansi escape (usually colors). I think it's ok for `chalk.green(' hello ')`, because spaces won't be colorized anyway. However, for `chalk.bgGreen(' hello ')` this results in:

![](https://user-images.githubusercontent.com/15624/37984190-9b3659be-31c3-11e8-891a-667c5c2a8edf.png)

Reason it was happening is because `wrap-ansi` splits input string by space here https://github.com/chalk/wrap-ansi/blob/master/index.js#L82.

```js
const words = chalk.bgGreen(' hello ');
const parts = words.split(' ');
//=> ['opening escape', 'hello', 'closing escape']
```

This PR fixes this case by scanning result of `split()` and joining opening escape, content and closing escape (following is pseudo code).

```js
const normalizedParts = normalizeParts(parts);
//=> ['opening escape hello closing escape']
```

This PR is still failing, because it doesn't yet handle `chalk.bgGreen(' hello ' + chalk.red('world'))` case. Any help is appreciated!