### PR TITLE
Force chalk to enable color codes for testing

### DIFF
--- a/test.js
+++ b/test.js
@@ -5,6 +5,7 @@ import stripAnsi from 'strip-ansi';
 import wrapAnsi from '.';
 
 chalk.enabled = true;
+chalk.level = 1;
 
 // When "hard" is false
 


### PR DESCRIPTION
Some tests require that color codes function properly.  This fixes
situations where STDOUT does not support color, for example:
`npm test | tee output`.