### PR TITLE
Update to strip-ansi v6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 	"dependencies": {
 		"ansi-styles": "^4.0.0",
 		"string-width": "^4.1.0",
-		"strip-ansi": "^5.0.0"
+		"strip-ansi": "^6.0.0"
 	},
 	"devDependencies": {
 		"ava": "^2.1.0",


### PR DESCRIPTION
strip-ansi@6 is only semver major because it dropped support for node.js 6, not a breaking change here.

This is part of an effort to make the next version of `yargs` use a single copy of `strip-ansi` (other PR at sindresorhus/string-width#24).