### PR TITLE
Add TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -39,4 +39,3 @@ console.log(wrapAnsi(input, 20));
 ```
 */
 export default function wrapAnsi(string: string, columns: number, options?: Options): string;
-

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,21 +4,21 @@ interface Options {
 
 	@default false
 	*/
-	readonly hard?: boolean | undefined;
+	readonly hard?: boolean;
 
 	/**
 	By default, an attempt is made to split words at spaces, ensuring that they don't extend past the configured columns. If wordWrap is `false`, each column will instead be completely filled splitting words as necessary.
 
 	@default true
 	*/
-	readonly wordWrap?: boolean | undefined;
+	readonly wordWrap?: boolean;
 
 	/**
 	Whitespace on all lines is removed by default. Set this option to `false` if you don't want to trim.
 
 	@default true
 	*/
-	readonly trim?: boolean | undefined;
+	readonly trim?: boolean;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-interface Options {
+export type Options = {
 	/**
 	By default the wrap is soft, meaning long words may extend past the column width. Setting this to `true` will make it hard wrap at the column width.
 
@@ -19,14 +19,13 @@ interface Options {
 	@default true
 	*/
 	readonly trim?: boolean;
-}
+};
 
 /**
 Wrap words to the specified column width.
 
-@param string String with ANSI escape codes. Like one styled by [`chalk`](https://github.com/chalk/chalk). Newline characters will be normalized to `\n`.
-@param columns Number of columns to wrap the text to.
-@param options
+@param string - String with ANSI escape codes. Like one styled by [`chalk`](https://github.com/chalk/chalk). Newline characters will be normalized to `\n`.
+@param columns - Number of columns to wrap the text to.
 
 @example
 ```
@@ -39,6 +38,5 @@ const input = 'The quick brown ' + chalk.red('fox jumped over ') +
 console.log(wrapAnsi(input, 20));
 ```
 */
-declare function wrapAnsi(string: string, columns: number, options?: Options): string;
+export default function wrapAnsi(string: string, columns: number, options?: Options): string;
 
-export default wrapAnsi;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,33 @@
+interface Options {
+	/**
+	By default the wrap is soft, meaning long words may extend past the column width. Setting this to `true` will make it hard wrap at the column width.
+
+	@default false
+	*/
+	hard?: boolean | undefined;
+
+	/**
+	By default, an attempt is made to split words at spaces, ensuring that they don't extend past the configured columns. If wordWrap is `false`, each column will instead be completely filled splitting words as necessary.
+
+	@default true
+	*/
+	wordWrap?: boolean | undefined;
+
+	/**
+	Whitespace on all lines is removed by default. Set this option to `false` if you don't want to trim.
+
+	@default true
+	*/
+	trim?: boolean | undefined;
+}
+
+/**
+Wrap words to the specified column width.
+
+@param input String with ANSI escape codes. Like one styled by [`chalk`](https://github.com/chalk/chalk). Newline characters will be normalized to `\n`.
+@param columns Number of columns to wrap the text to.
+@param options
+*/
+declare function wrapAnsi(string: string, columns: number, options?: Options): string;
+
+export default wrapAnsi;

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,21 +4,21 @@ interface Options {
 
 	@default false
 	*/
-	hard?: boolean | undefined;
+	readonly hard?: boolean | undefined;
 
 	/**
 	By default, an attempt is made to split words at spaces, ensuring that they don't extend past the configured columns. If wordWrap is `false`, each column will instead be completely filled splitting words as necessary.
 
 	@default true
 	*/
-	wordWrap?: boolean | undefined;
+	readonly wordWrap?: boolean | undefined;
 
 	/**
 	Whitespace on all lines is removed by default. Set this option to `false` if you don't want to trim.
 
 	@default true
 	*/
-	trim?: boolean | undefined;
+	readonly trim?: boolean | undefined;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,7 @@ interface Options {
 /**
 Wrap words to the specified column width.
 
-@param input String with ANSI escape codes. Like one styled by [`chalk`](https://github.com/chalk/chalk). Newline characters will be normalized to `\n`.
+@param string String with ANSI escape codes. Like one styled by [`chalk`](https://github.com/chalk/chalk). Newline characters will be normalized to `\n`.
 @param columns Number of columns to wrap the text to.
 @param options
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,6 +27,17 @@ Wrap words to the specified column width.
 @param input String with ANSI escape codes. Like one styled by [`chalk`](https://github.com/chalk/chalk). Newline characters will be normalized to `\n`.
 @param columns Number of columns to wrap the text to.
 @param options
+
+@example
+```
+import chalk from 'chalk';
+import wrapAnsi from 'wrap-ansi';
+
+const input = 'The quick brown ' + chalk.red('fox jumped over ') +
+	'the lazy ' + chalk.green('dog and then ran away with the unicorn.');
+
+console.log(wrapAnsi(input, 20));
+```
 */
 declare function wrapAnsi(string: string, columns: number, options?: Options): string;
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,11 @@
+import {expectType} from 'tsd';
+import wrapAnsi from './index.js';
+
+expectType<string>(wrapAnsi('input', 80));
+expectType<string>(wrapAnsi('input', 80, {}));
+expectType<string>(wrapAnsi('input', 80, {hard: true}));
+expectType<string>(wrapAnsi('input', 80, {hard: false}));
+expectType<string>(wrapAnsi('input', 80, {trim: true}));
+expectType<string>(wrapAnsi('input', 80, {trim: false}));
+expectType<string>(wrapAnsi('input', 80, {wordWrap: true}));
+expectType<string>(wrapAnsi('input', 80, {wordWrap: false}));

--- a/package.json
+++ b/package.json
@@ -11,15 +11,19 @@
 		"url": "https://sindresorhus.com"
 	},
 	"type": "module",
-	"exports": "./index.js",
+	"exports": {
+		"types": "./index.d.ts",
+		"default": "./index.js"
+	},
 	"engines": {
 		"node": ">=12"
 	},
 	"scripts": {
-		"test": "xo && nyc ava"
+		"test": "xo && nyc ava && tsd"
 	},
 	"files": [
-		"index.js"
+		"index.js",
+		"index.d.ts"
 	],
 	"keywords": [
 		"wrap",
@@ -59,6 +63,7 @@
 		"coveralls": "^3.1.1",
 		"has-ansi": "^5.0.1",
 		"nyc": "^15.1.0",
+		"tsd": "^0.25.0",
 		"xo": "^0.44.0"
 	}
 }


### PR DESCRIPTION
The current type definition on DefinitelyTyped is broken when using ESM with "moduleResolution": "node16" (since the npm package it produces doesn't include "type": "module" in its package.json file, leading to TypeScript incorrectly typing the default export (`import wrapAnsi from 'wrap-ansi'`) as `wrapAnsi.default`).

Since the types are broken, instead of fixing them, I thought that I might as well just copy them to the wrap-ansi package itself so users don't need to separately install the type definition when importing `wrap-ansi`.