### PR TITLE
Performance - Drastically improve worst case regex performance

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,8 +41,9 @@ const wrapWord = (rows, word, columns) => {
 		}
 
 		if (ESCAPES.has(character)) {
-			const ansiEscapeLinkCandidate = characters.slice(index + 1, index + 1 + ANSI_ESCAPE_LINK.length).join('');
 			isInsideEscape = true;
+
+			const ansiEscapeLinkCandidate = characters.slice(index + 1, index + 1 + ANSI_ESCAPE_LINK.length).join('');
 			isInsideLinkEscape = ansiEscapeLinkCandidate === ANSI_ESCAPE_LINK;
 		}
 

--- a/index.js
+++ b/index.js
@@ -41,8 +41,9 @@ const wrapWord = (rows, word, columns) => {
 		}
 
 		if (ESCAPES.has(character)) {
+			const ansiEscapeLinkCandidate = characters.slice(index + 1, index + 1 + ANSI_ESCAPE_LINK.length).join('');
 			isInsideEscape = true;
-			isInsideLinkEscape = characters.slice(index + 1).join('').startsWith(ANSI_ESCAPE_LINK);
+			isInsideLinkEscape = ansiEscapeLinkCandidate === ANSI_ESCAPE_LINK;
 		}
 
 		if (isInsideEscape) {
@@ -164,13 +165,17 @@ const exec = (string, columns, options = {}) => {
 		rows = rows.map(row => stringVisibleTrimSpacesRight(row));
 	}
 
-	const pre = [...rows.join('\n')];
+	const preString = rows.join('\n');
+	const pre = [...preString];
+
+	// Account for unicode characters with length 2
+	let preStringIndex = 0;
 
 	for (const [index, character] of pre.entries()) {
 		returnValue += character;
 
 		if (ESCAPES.has(character)) {
-			const {groups} = new RegExp(`(?:\\${ANSI_CSI}(?<code>\\d+)m|\\${ANSI_ESCAPE_LINK}(?<uri>.*)${ANSI_ESCAPE_BELL})`).exec(pre.slice(index).join('')) || {groups: {}};
+			const {groups} = new RegExp(`(?:\\${ANSI_CSI}(?<code>\\d+)m|\\${ANSI_ESCAPE_LINK}(?<uri>.*)${ANSI_ESCAPE_BELL})`).exec(preString.slice(preStringIndex)) || {groups: {}};
 			if (groups.code !== undefined) {
 				const code = Number.parseFloat(groups.code);
 				escapeCode = code === END_CODE ? undefined : code;
@@ -198,6 +203,8 @@ const exec = (string, columns, options = {}) => {
 				returnValue += wrapAnsiHyperlink(escapeUrl);
 			}
 		}
+
+		preStringIndex += character.length;
 	}
 
 	return returnValue;

--- a/index.js
+++ b/index.js
@@ -168,7 +168,7 @@ const exec = (string, columns, options = {}) => {
 	const preString = rows.join('\n');
 	const pre = [...preString];
 
-	// Account for unicode characters with length 2
+	// We need to keep a separate index as `String#slice()` works on Unicode code units, while `pre` is an array of codepoints.
 	let preStringIndex = 0;
 
 	for (const [index, character] of pre.entries()) {


### PR DESCRIPTION
Problem:
Very poor performance when testing certain regexes due to unnecessary conversion to/from string/array.

Impact:
Some of the reporters in Vitest that depend on this code are extremely slow. (See: https://github.com/vitest-dev/vitest/issues/2602)

Notes:
While time complexity of both operations is theoretically the same, seems the VM is optimizing string specific operations much better than the conversion back/forth. 

Future:
In this case can run a single global regex on the entire string up front rather than re-allocating a new substring at each index. But for now this is simple and solves the issue.