### PR TITLE
refactor: replace strip-ansi with built-in util.stripVTControlCharacters

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
+import {stripVTControlCharacters} from 'node:util';
 import stringWidth from 'string-width';
-import stripAnsi from 'strip-ansi';
 import ansiStyles from 'ansi-styles';
 
 const ANSI_ESCAPE = '\u001B';
@@ -248,7 +248,7 @@ const wrapWord = (rows, word, columns) => {
 
 	let isInsideEscape = false;
 	let isInsideLinkEscape = false;
-	let visible = stringWidth(stripAnsi(rows.at(-1)));
+	let visible = stringWidth(stripVTControlCharacters(rows.at(-1)));
 
 	for (const [index, character] of characters.entries()) {
 		const characterLength = stringWidth(character);

--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
 	],
 	"dependencies": {
 		"ansi-styles": "^6.2.3",
-		"string-width": "^8.2.0",
-		"strip-ansi": "^7.1.2"
+		"string-width": "^8.2.0"
 	},
 	"devDependencies": {
 		"ava": "^6.4.1",

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import chalk from 'chalk';
 import hasAnsi from 'has-ansi';
-import stripAnsi from 'strip-ansi';
+import {stripVTControlCharacters as stripAnsi} from 'node:util';
 import wrapAnsi from './index.js';
 
 chalk.level = 1;


### PR DESCRIPTION
## Summary
- Replaced the `strip-ansi` dependency with Node.js built-in `util.stripVTControlCharacters`
- Removed `strip-ansi` from `package.json` dependencies
- `util.stripVTControlCharacters` is available since Node.js 16.11.0, well within the `>=20` engine requirement

This reduces the dependency tree by removing one package.

All 54 tests pass.

Closes #55