### PR TITLE
Replace strip-ansi dependency with built-in util.stripVTControlCharacters

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
+import {stripVTControlCharacters as stripAnsi} from 'node:util';
 import stringWidth from 'string-width';
-import stripAnsi from 'strip-ansi';
 import ansiStyles from 'ansi-styles';
 
 const ANSI_ESCAPE = '\u001B';

--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
 	],
 	"dependencies": {
 		"ansi-styles": "^6.2.3",
-		"string-width": "^8.2.0",
-		"strip-ansi": "^7.1.2"
+		"string-width": "^8.2.0"
 	},
 	"devDependencies": {
 		"ava": "^6.4.1",

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
+import {stripVTControlCharacters as stripAnsi} from 'node:util';
 import test from 'ava';
 import chalk from 'chalk';
 import hasAnsi from 'has-ansi';
-import stripAnsi from 'strip-ansi';
 import wrapAnsi from './index.js';
 
 chalk.level = 1;


### PR DESCRIPTION
## What
Replaces the external `strip-ansi` dependency with Node.js built-in `util.stripVTControlCharacters` API.

## Why
- Available since Node v16.11.0 — no compatibility concern since the package requires Node >= 20
- Removes an unnecessary external dependency
- One less package to install for consumers of wrap-ansi

## Changes
- **index.js**: Replace `import stripAnsi from "strip-ansi"` with `import {stripVTControlCharacters as stripAnsi} from "node:util"`
- **test.js**: Same import replacement
- **package.json**: Remove `strip-ansi` from dependencies

## Verification
All 54 existing tests pass with this change.

Fixes #55